### PR TITLE
chore(cicd): add concurrency to release wf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     types:
       - "published"
 
+concurrency: release
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
see:
- https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
- https://docs.github.com/en/actions/using-jobs/using-concurrency