### PR TITLE
feat(cicd): auto release

### DIFF
--- a/.github/workflows/release-drafter-labeler.yml
+++ b/.github/workflows/release-drafter-labeler.yml
@@ -1,10 +1,6 @@
-name: release-drafter
+name: release-drafter labeler
 
 on:
-  push:
-    branches:
-      - main
-
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
@@ -31,6 +27,3 @@ jobs:
           config-name: release-drafter.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    outputs:
-      tag: ${{ steps.releasedrafter.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,41 @@
 name: release
 
-on:
-  release:
-    types:
-      - "published"
-
 concurrency: release
 
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
+  release-drafter:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # for release-drafter/release-drafter to create a github release
+      pull-requests: write # for release-drafter/release-drafter to add label to PR
+
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        id: releasedrafter
+        with:
+          config-name: release-drafter.yaml
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    outputs:
+      tag: ${{ steps.releasedrafter.outputs.tag_name }}
+
   release:
     runs-on: ubuntu-latest
+    needs: release-drafter
 
     steps:
       - name: checkout repository
@@ -34,17 +60,17 @@ jobs:
 
       - name: bump version (npm)
         shell: bash
-        run: npm version --no-git-tag-version --new-version ${{ github.event.release.tag_name }}
+        run: npm version --no-git-tag-version --new-version ${{ needs.release-drafter.outputs.tag }}
 
       - name: bump version (README)
         shell: bash
-        run: sed -i -E "s/@(v[0-9]*\.[0-9]*\.[0-9]*)/@${{ github.event.release.tag_name }}/g" README.md
+        run: sed -i -E "s/@(v[0-9]*\.[0-9]*\.[0-9]*)/@${{ needs.release-drafter.outputs.tag }}/g" README.md
 
       - name: commit version bump
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: |
-            chore(release): update version to ${{ github.event.release.tag_name }}
+            chore(release): update version to ${{ needs.release-drafter.outputs.tag }}
 
             skip-checks: true
           branch: main
@@ -59,17 +85,17 @@ jobs:
       - name: commit binaries
         shell: bash
         run: |
-          git checkout -b release/${{ github.event.release.tag_name }}
+          git checkout -b release/${{ needs.release-drafter.outputs.tag }}
           git add --force dist/
           git commit \
-            -m "chore(release): add binaries ${{ github.event.release.tag_name }}" \
+            -m "chore(release): add binaries ${{ needs.release-drafter.outputs.tag }}" \
             -m "skip-checks: true"
 
       - name: move release tag
         shell: bash
         run: |
-          git tag --force ${{ github.event.release.tag_name }} HEAD
-          git push --force origin ${{ github.event.release.tag_name }}
+          git tag --force ${{ needs.release-drafter.outputs.tag }} HEAD
+          git push --force origin ${{ needs.release-drafter.outputs.tag }}
 
       - name: update latest tag
         shell: bash


### PR DESCRIPTION
- release-drafter-labeler will auto label PRs
- release will first draft and publish release
- release will then build and update release

The release will not be triggered againg because the generated commits will skip any check (this includes any workflow). Also if multiple PRs are (auto) merged at the same time the concurrency of the release drafter prevent a release in parallel which would occur in an error.