### PR TITLE
fix dependabot autorelease workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,4 +15,6 @@ jobs:
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN will not trigger any workflow - therefore the PAT will be required
+          # see: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v3
         with:
-          # Using PAT because action will be triggered automatically and has no write permission
+          # Using PAT because if the action will be triggered automatically by dependabot the GITHUB_TOKEN has no write permission
           # see: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
           token: ${{ secrets.PAT }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: release
 
-concurrency: release
+concurrency:
+  group: release
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,35 @@ permissions:
   contents: read
 
 jobs:
+  validate-release-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if release should be skipped
+        id: lastcommit
+        shell: bash
+        # As described in the docs the skip-checks should prevent this push-triggered action from execution.
+        # But the action still triggers - not sure why this is the case.
+        # see: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+        run: |
+          if [[ ${{ toJSON(github.event.head_commit.message) }} == *"skip-checks: true"* ]]; then
+            echo "'skip-checks: true' found"
+            echo "::set-output name=skipchecks::true"
+          else
+            echo "'skip-checks: true' NOT found"
+            echo "::set-output name=skipchecks::false"
+          fi
+    outputs:
+      skipchecks: ${{ steps.lastcommit.outputs.skipchecks }}
+
   release-drafter:
     runs-on: ubuntu-latest
+    needs: validate-release-trigger
 
     permissions:
       contents: write # for release-drafter/release-drafter to create a github release
       pull-requests: write # for release-drafter/release-drafter to add label to PR
+
+    if: ${{ needs.validate-release-trigger.outputs.skipchecks == 'false' }}
 
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"


### PR DESCRIPTION
To release with dependabot the workflow has to be reconsidered.

- use PAT for automerge to trigger release workflow
  _if the `GITHUB_TOKEN` is used the release workflow will not be triggered._
- the concurrency has to be configured to cancel previous workflow
- the relese workflow requires check if the release has to be skipped
  _if the release was triggered by the release workflow itself it should not be runned again - this can be solved with `skip-checks` option - which will be manually checked against because it triggers curiously_

fixes #29